### PR TITLE
Add NichirinScript language powered by Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,106 @@
-# AI
-AI
+# NichirinScript
+
+NichirinScript es un lenguaje temático inspirado en *Kimetsu no Yaiba* que se
+apoya totalmente en el intérprete estándar de Python. El repositorio incluye
+un traductor y un pequeño runtime que permiten escribir archivos `.nichirin`
+utilizando vocabulario del anime y ejecutarlos como si fueran programas
+Python.
+
+## Características del lenguaje
+
+Las reglas son ligeras y buscan evocar el mundo de los cazadores de demonios
+sin dejar de lado la sintaxis conocida de Python. Estas son las principales
+construcciones disponibles:
+
+| NichirinScript                           | Python equivalente        | Descripción |
+| ---------------------------------------- | ------------------------- | ----------- |
+| `aliento nombre(parametros):`            | `def nombre(parametros):` | Declara funciones utilizando el término “aliento”. |
+| `pilar Nombre(Hashira):`                 | `class Nombre(Hashira):`  | Define clases llamadas “pilares”. |
+| `si cazador condicion:`                  | `if condicion:`           | Condicional principal. |
+| `sino hashira condicion:`                | `elif condicion:`         | Rama intermedia del condicional. |
+| `sino demonio:`                          | `else:`                   | Rama final. |
+| `mision x en rango(...):`                | `for x in range(...):`    | Bucle `for`. Se acepta cualquier iterable tras `en`. |
+| `infinito mientras condicion:`           | `while condicion:`        | Bucle `while`. |
+| `respiracion total` / `respiracion constante` | `while True`             | Bucle infinito listo para romperse con `mata demonio`. |
+| `respiracion total concentracion:`       | `while True:`             | Otra forma épica de iniciar un bucle infinito. |
+| `kagura("mensaje")`                    | `print("mensaje")`       | Envía mensajes, inspirado en la Danza del Dios del Fuego. |
+| `cuervo("texto")`                      | `input("texto")`         | Solicita datos como los cuervos mensajeros. |
+| `regresa valor`                          | `return valor`            | Retorno de funciones. |
+| `mata demonio`                           | `break`                   | Sale de bucles. |
+| `persevera cazador`                      | `continue`                | Salta a la siguiente iteración. |
+| `juramento modulo`                       | `import modulo`           | Importa módulos estándar de Python. |
+| `juramento de la/las/los paquete`        | `from paquete`            | Import estilo `from`. |
+
+Cualquier otro elemento (operadores, literales, indentación, comentarios con
+`#`, etc.) se comporta exactamente igual que en Python, lo que facilita la
+creación de scripts elaborados manteniendo la ambientación del anime.
+
+## Runtime con sabor a Kimetsu
+
+El paquete proporciona un módulo `nichirinscript.runtime` que expone utilidades
+para modelar respiraciones y técnicas:
+
+```python
+from nichirinscript.runtime import (
+    Tecnica,
+    Respiracion,
+    tecnica,
+    forjar_respiration,
+    invocar_respiration,
+    grito_de_guerra,
+)
+```
+
+Estas funciones permiten registrar respiraciones, listar técnicas y producir
+mensajes temáticos dentro de los programas traducidos.
+
+## Ejecución
+
+El repositorio incluye un ejecutor CLI. Una vez dentro del directorio del
+proyecto se puede lanzar un archivo NichirinScript así:
+
+```bash
+python -m nichirinscript ruta/al/programa.nichirin
+```
+
+Opcionalmente, añade `--emit-python` para imprimir el código Python traducido
+antes de ejecutarlo.
+
+## Ejemplo
+
+El archivo [`examples/mision_principal.nichirin`](examples/mision_principal.nichirin)
+demuestra varios elementos del lenguaje:
+
+```text
+juramento math
+
+aliento danza_del_dios_del_fuego(nombre_cazador):
+    kagura(grito_de_guerra(nombre_cazador))
+    respiracion = invocar_respiration("Solar")
+    si cazador respiracion:
+        si cazador respiracion.tecnicas:
+            kagura("Formas heredadas:")
+            mision forma en respiracion.desplegar():
+                kagura(f" - {forma}")
+        sino demonio:
+            kagura("Tanjiro aún no ha dominado ninguna forma.")
+
+si cazador __name__ == "__main__":
+    forjar_respiration(
+        "Solar",
+        "Kamado Tanjiro",
+        [
+            tecnica("Primera Forma", "Golpe circular ardiente"),
+            tecnica("Tercera Forma", "Danza purificadora"),
+        ],
+    )
+
+    danza_del_dios_del_fuego("Kamado Tanjiro")
+```
+
+Al ejecutarlo, verás una salida completamente funcional gracias a que el
+traductor entrega Python válido al intérprete.
+
+## Pruebas
+
+Ejecuta `pytest` para comprobar que el traductor respeta las reglas anteriores.

--- a/examples/mision_principal.nichirin
+++ b/examples/mision_principal.nichirin
@@ -1,0 +1,24 @@
+juramento math
+
+aliento danza_del_dios_del_fuego(nombre_cazador):
+    kagura(grito_de_guerra(nombre_cazador))
+    respiracion = invocar_respiration("Solar")
+    si cazador respiracion:
+        si cazador respiracion.tecnicas:
+            kagura("Formas heredadas:")
+            mision forma en respiracion.desplegar():
+                kagura(f" - {forma}")
+        sino demonio:
+            kagura("Tanjiro aún no ha dominado ninguna forma.")
+
+si cazador __name__ == "__main__":
+    forjar_respiration(
+        "Solar",
+        "Kamado Tanjiro",
+        [
+            tecnica("Primera Forma", "Golpe circular ardiente"),
+            tecnica("Tercera Forma", "Danza purificadora"),
+        ],
+    )
+
+    danza_del_dios_del_fuego("Kamado Tanjiro")

--- a/nichirinscript/__init__.py
+++ b/nichirinscript/__init__.py
@@ -1,0 +1,4 @@
+"""NichirinScript package."""
+from .translator import NichirinTranslator, translate_text
+
+__all__ = ["NichirinTranslator", "translate_text"]

--- a/nichirinscript/__main__.py
+++ b/nichirinscript/__main__.py
@@ -1,0 +1,79 @@
+"""NichirinScript command line interface."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import runpy
+import sys
+from typing import Any, Dict
+
+from . import runtime
+from .translator import translate_text
+
+
+def build_namespace(filename: str) -> Dict[str, Any]:
+    """Return an execution namespace pre-populated with runtime helpers."""
+
+    namespace: Dict[str, Any] = {
+        "__name__": "__main__",
+        "__file__": filename,
+    }
+    namespace.update({name: getattr(runtime, name) for name in runtime.__all__})
+    return namespace
+
+
+def execute_file(path: pathlib.Path, *, emit_python: bool = False) -> int:
+    """Translate and execute a NichirinScript program."""
+
+    source = path.read_text(encoding="utf-8")
+    python_code = translate_text(source)
+
+    if emit_python:
+        sys.stdout.write(python_code)
+        if not python_code.endswith("\n"):
+            sys.stdout.write("\n")
+
+    namespace = build_namespace(str(path))
+    exec(python_code, namespace)  # noqa: S102 - executing trusted local source
+    return 0
+
+
+def execute_module(module: str) -> int:
+    """Run a NichirinScript-aware Python module."""
+
+    runpy.run_module(module, run_name="__main__")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="nichirinscript", description="Ejecutor de NichirinScript")
+    parser.add_argument("program", nargs="?", help="Archivo .nichirin a ejecutar")
+    parser.add_argument(
+        "-m",
+        "--module",
+        dest="module",
+        help="Ejecuta un módulo Python como si fuese __main__",
+    )
+    parser.add_argument(
+        "--emit-python",
+        action="store_true",
+        help="Muestra el código Python traducido antes de ejecutar",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.module:
+        return execute_module(args.module)
+
+    if not args.program:
+        parser.error("Debes especificar un archivo .nichirin o usar -m")
+
+    program_path = pathlib.Path(args.program)
+    if not program_path.exists():
+        parser.error(f"No existe el archivo {program_path}")
+
+    return execute_file(program_path, emit_python=args.emit_python)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    raise SystemExit(main())

--- a/nichirinscript/runtime.py
+++ b/nichirinscript/runtime.py
@@ -1,0 +1,77 @@
+"""Runtime helpers for NichirinScript programs.
+
+The runtime keeps a compact piece of Kimetsu no Yaiba lore so that programs
+can interact with familiar entities.  The helpers are optional but they make
+it easier to build immersive examples while still running on the Python
+interpreter.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class Tecnica:
+    """Una técnica de respiración."""
+
+    nombre: str
+    descripcion: str
+
+    def ejecutar(self) -> str:
+        return f"{self.nombre}: {self.descripcion}"
+
+
+@dataclass
+class Respiracion:
+    """Representa un estilo de respiración."""
+
+    estilo: str
+    usuario: str
+    tecnicas: List[Tecnica]
+
+    def desplegar(self) -> List[str]:
+        return [tecnica.ejecutar() for tecnica in self.tecnicas]
+
+
+RESPIRACIONES: Dict[str, Respiracion] = {}
+
+
+def tecnica(nombre: str, descripcion: str) -> Tecnica:
+    """Crea una técnica con su descripción."""
+
+    return Tecnica(nombre=nombre, descripcion=descripcion)
+
+
+def forjar_respiration(estilo: str, usuario: str, tecnicas: Iterable[Tecnica]) -> Respiracion:
+    """Registra un estilo de respiración en el compendio global."""
+
+    registro = Respiracion(estilo=estilo, usuario=usuario, tecnicas=list(tecnicas))
+    RESPIRACIONES[estilo] = registro
+    return registro
+
+
+def invocar_respiration(estilo: str) -> Respiracion:
+    """Recupera un estilo de respiración previamente registrado."""
+
+    try:
+        return RESPIRACIONES[estilo]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise KeyError(f"No existe la respiración '{estilo}'. Usa forjar_respiration primero.") from exc
+
+
+def grito_de_guerra(nombre: str) -> str:
+    """Devuelve un mensaje heroico para ambientar las misiones."""
+
+    return f"\U0001f5e1️ ¡{nombre}, que tu espada Nichirin ilumine la noche!"
+
+
+__all__ = [
+    "Tecnica",
+    "Respiracion",
+    "RESPIRACIONES",
+    "tecnica",
+    "forjar_respiration",
+    "invocar_respiration",
+    "grito_de_guerra",
+]

--- a/nichirinscript/translator.py
+++ b/nichirinscript/translator.py
@@ -1,0 +1,76 @@
+"""NichirinScript translator.
+
+This module turns NichirinScript source code into valid Python code. The
+translator is intentionally lightweight: the syntax sugar is replaced via
+pattern rules so that the resulting program can be executed directly by the
+standard Python interpreter.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import re
+from typing import Iterable, List
+
+
+@dataclass
+class NichirinTranslator:
+    """Translate NichirinScript code into Python."""
+
+    prefix_rules: List[tuple[str, str]] = field(default_factory=lambda: [
+        ("juramento de las ", "from "),
+        ("juramento de los ", "from "),
+        ("juramento de la ", "from "),
+        ("juramento ", "import "),
+        ("aliento ", "def "),
+        ("pilar ", "class "),
+        ("si cazador ", "if "),
+        ("sino hashira ", "elif "),
+        ("sino demonio", "else"),
+        ("infinito mientras ", "while "),
+        ("respiracion total concentracion", "while True"),
+        ("regresa ", "return "),
+        ("mata demonio", "break"),
+        ("persevera cazador", "continue"),
+    ])
+
+    regex_rules: List[tuple[re.Pattern[str], str]] = field(default_factory=lambda: [
+        (re.compile(r"\bmision (?P<var>[A-Za-z_][\w]*)\s+en\b"), r"for \g<var> in"),
+        (re.compile(r"(?<!\w)kagura(?=\s*\()"), "print"),
+        (re.compile(r"(?<!\w)cuervo(?=\s*\()"), "input"),
+        (re.compile(r"\brespiracion total\b"), "while True"),
+        (re.compile(r"\brespiracion constante\b"), "while True"),
+        (re.compile(r"\brango\b"), "range"),
+    ])
+
+    def translate_line(self, line: str) -> str:
+        """Translate a single line preserving indentation."""
+        if not line.strip():
+            return line
+
+        indent_match = re.match(r"^\s*", line)
+        indent = indent_match.group(0) if indent_match else ""
+        stripped = line[len(indent):]
+
+        for prefix, replacement in self.prefix_rules:
+            if stripped.startswith(prefix):
+                stripped = replacement + stripped[len(prefix):]
+                break
+
+        translated = stripped
+        for pattern, replacement in self.regex_rules:
+            translated = pattern.sub(replacement, translated)
+
+        return f"{indent}{translated}"
+
+    def translate(self, source: Iterable[str]) -> str:
+        """Translate an iterable of lines into executable Python code."""
+        return "".join(self.translate_line(line) for line in source)
+
+
+def translate_text(text: str) -> str:
+    """Helper to translate NichirinScript text into Python code."""
+    translator = NichirinTranslator()
+    return translator.translate(text.splitlines(keepends=True))
+
+
+__all__ = ["NichirinTranslator", "translate_text"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,95 @@
+import textwrap
+
+import pytest
+
+from nichirinscript.translator import translate_text
+
+
+def dedent(source: str) -> str:
+    return textwrap.dedent(source).lstrip("\n")
+
+
+def test_basic_translation():
+    source = dedent(
+        """
+        aliento saludo(nombre):
+            kagura(f"Hola, {nombre}")
+            si cazador nombre == "Tanjiro":
+                regresa "Nezuko te espera"
+            sino demonio:
+                regresa "Hashira en camino"
+        """
+    )
+
+    expected = dedent(
+        """
+        def saludo(nombre):
+            print(f"Hola, {nombre}")
+            if nombre == "Tanjiro":
+                return "Nezuko te espera"
+            else:
+                return "Hashira en camino"
+        """
+    )
+
+    assert translate_text(source) == expected
+
+
+def test_loop_and_runtime_words():
+    source = dedent(
+        """
+        mision demonio en rango(3):
+            kagura(demonio)
+            si cazador demonio == 1:
+                persevera cazador
+            si cazador demonio == 2:
+                mata demonio
+        """
+    )
+
+    translated = translate_text(source)
+    assert "for demonio in range(3):" in translated
+    assert translated.count("continue") == 1
+    assert translated.count("break") == 1
+
+
+def test_respiration_loop_synonyms():
+    source = dedent(
+        """
+        respiracion total:
+            mata demonio
+        respiracion constante:
+            mata demonio
+        respiracion total concentracion:
+            mata demonio
+        """
+    )
+
+    translated = translate_text(source)
+    assert translated.count("while True") == 3
+
+
+def test_input_keyword_only_when_calling():
+    source = dedent(
+        """
+        mensaje = "cuervo mensajero"
+        respuesta = cuervo("¿Listo?")
+        kagura(mensaje)
+        kagura(respuesta)
+        """
+    )
+
+    translated = translate_text(source)
+    assert "mensaje = \"cuervo mensajero\"" in translated
+    assert "respuesta = input(\"¿Listo?\")" in translated
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        ("juramento math\n", "import math\n"),
+        ("juramento de la coleccion import Counter\n", "from coleccion import Counter\n"),
+    ],
+)
+def test_import_synonyms(line, expected):
+    assert translate_text(line) == expected


### PR DESCRIPTION
## Summary
- implement the NichirinScript translator and runtime helpers inspired by Kimetsu no Yaiba
- document the language, provide an example program, and expose a CLI runner
- cover the translator behaviour with pytest regression tests

## Testing
- pytest
- python -m nichirinscript --emit-python examples/mision_principal.nichirin

------
https://chatgpt.com/codex/tasks/task_e_68d1750e26ac8322849c0223faebe828